### PR TITLE
Support python binary on non-standard locations

### DIFF
--- a/play.py
+++ b/play.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from logic import TicTacToe2Players
 from logic import TicTacToeAi


### PR DESCRIPTION
This makes it work on NixOS.